### PR TITLE
Added support for Code 39 and 9 barcode digits

### DIFF
--- a/iOS/QuickScan/QuickScanModeView.swift
+++ b/iOS/QuickScan/QuickScanModeView.swift
@@ -87,7 +87,8 @@ struct QuickScanModeView: View {
     func handleScan(result: Result<String, CodeScannerView.ScanError>) {
         switch result {
         case .success(let barcodeString):
-            guard ((barcodeString.count == 13) || (barcodeString.count == 8)) else {
+            guard ((barcodeString.count == 13) || (barcodeString.count == 8) ||
+                    (barcodeString.count == 9)) else {
                 toastTypeSuccess = .invalidBarcode
                 return
             }
@@ -139,7 +140,7 @@ struct QuickScanModeView: View {
     }
     
     var bodyContent: some View {
-        CodeScannerView(codeTypes: [.ean8, .ean13], scanMode: .continuous, simulatedData: "5901234123457", isPaused: $isScanPaused, completion: self.handleScan)
+        CodeScannerView(codeTypes: [.ean8, .ean13, .code39], scanMode: .continuous, simulatedData: "5901234123457", isPaused: $isScanPaused, completion: self.handleScan)
             .overlay(modePicker, alignment: .top)
             .sheet(item: $activeSheet) { item in
                 switch item {


### PR DESCRIPTION
Hi @supergeorg,

with this PR, I would like to add support for code 39 barcodes.

Background: I would like to use Grocy also for managing my medicine cabinet. Pharmaceutical products in Germany are identified by a PZN number. This number is printed as code 39 barcodes on drug packages (see here: https://www.eancode.net/PZN-Deutschland.html).
Usually, these barcodes encode 8 digits (including a leading dash). However, I also found a package with 9 digits (including leading dash). That is why I have also added the support for 9 digits.

It would be great if you integrate this PR. In case you have further questions, I am happy to discuss.

Thank you and BR
André 