### PR TITLE
Added support for code 39 

### DIFF
--- a/Shared/Views/Additional/OpenFoodFactsScannerView.swift
+++ b/Shared/Views/Additional/OpenFoodFactsScannerView.swift
@@ -28,7 +28,7 @@ struct OpenFoodFactsScannerView: View {
     var body: some View {
         // DOESNT WORK, https://stackoverflow.com/questions/67276205/swiftui-navigationlink-for-ios-14-5-not-working
         NavigationLink(destination: OpenFoodFactsView(barcode: scanBarcode), isActive: $isShowingResult) {
-            CodeScannerView(codeTypes: [.ean8, .ean13], scanMode: .once, simulatedData: simulatedData, completion: self.handleScan)
+            CodeScannerView(codeTypes: [.ean8, .ean13, .code39], scanMode: .once, simulatedData: simulatedData, completion: self.handleScan)
         }
     }
 }

--- a/Shared/Views/Components/ProductField.swift
+++ b/Shared/Views/Components/ProductField.swift
@@ -52,7 +52,7 @@ struct ProductField: View {
                     Image(systemName: MySymbols.barcodeScan)
                 })
                 .sheet(isPresented: $isShowingScanner) {
-                    CodeScannerView(codeTypes: [.ean8, .ean13], scanMode: .once, simulatedData: "5901234123457", completion: self.handleScan)
+                    CodeScannerView(codeTypes: [.ean8, .ean13, .code39], scanMode: .once, simulatedData: "5901234123457", completion: self.handleScan)
                 }
             }
             Text("").tag(nil as String?)

--- a/Shared/Views/MasterData/MDForms/MDBarcodeFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDBarcodeFormView.swift
@@ -29,8 +29,8 @@ struct MDBarcodeFormView: View {
     
     @State var isBarcodeCorrect: Bool = false
     private func checkBarcodeCorrect() -> Bool {
-        // check if EAN8 or EAN13
-        return (Int(barcode) != nil) && (barcode.count == 8 || barcode.count == 13)
+        // check if EAN8 or EAN13, or PZN 8/9
+        return (Int(barcode) != nil) && (barcode.count == 8 || barcode.count == 13 || barcode.count == 9)
     }
     
     private var product: MDProduct? {
@@ -170,7 +170,7 @@ struct MDBarcodeFormView: View {
                     Image(systemName: MySymbols.barcodeScan)
                 })
                 .sheet(isPresented: $isShowingScanner) {
-                    CodeScannerView(codeTypes: [.ean8, .ean13], scanMode: .once, simulatedData: "5901234123457", completion: self.handleScan)
+                    CodeScannerView(codeTypes: [.ean8, .ean13, .code39], scanMode: .once, simulatedData: "5901234123457", completion: self.handleScan)
                 }
                 #endif
             }

--- a/iOS/QuickScan/QuickScanModeView.swift
+++ b/iOS/QuickScan/QuickScanModeView.swift
@@ -87,7 +87,8 @@ struct QuickScanModeView: View {
     func handleScan(result: Result<String, CodeScannerView.ScanError>) {
         switch result {
         case .success(let barcodeString):
-            guard ((barcodeString.count == 13) || (barcodeString.count == 8)) else {
+            guard ((barcodeString.count == 13) || (barcodeString.count == 8) ||
+                    (barcodeString.count == 9)) else {
                 toastTypeSuccess = .invalidBarcode
                 return
             }
@@ -139,7 +140,7 @@ struct QuickScanModeView: View {
     }
     
     var bodyContent: some View {
-        CodeScannerView(codeTypes: [.ean8, .ean13], scanMode: .continuous, simulatedData: "5901234123457", isPaused: $isScanPaused, completion: self.handleScan)
+        CodeScannerView(codeTypes: [.ean8, .ean13, .code39], scanMode: .continuous, simulatedData: "5901234123457", isPaused: $isScanPaused, completion: self.handleScan)
             .overlay(modePicker, alignment: .top)
             .sheet(item: $activeSheet) { item in
                 switch item {


### PR DESCRIPTION
Hi @supergeorg,

with this PR, I would like to add support for code 39 barcodes - this time in all used scanners :-)

Background: I would like to use Grocy also for managing my medicine cabinet. Pharmaceutical products in Germany are identified by a PZN number. This number is printed as code 39 barcodes on drug packages (see here: https://www.eancode.net/PZN-Deutschland.html).
Usually, these barcodes encode 8 digits (including a leading dash). However, I also found a package with 9 digits (including leading dash). That is why I have also added the support for 9 digits.

It would be great if you integrate this PR. In case you have further questions, I am happy to discuss.

Thank you and BR
André