### PR TITLE
Fix: QuickScan purchase confirmation

### DIFF
--- a/Shared/Views/Settings/SettingsAppView.swift
+++ b/Shared/Views/Settings/SettingsAppView.swift
@@ -23,7 +23,7 @@ struct SettingsAppView: View {
     let refreshIntervals: [Int] = [3, 5, 10, 30, 60, 300]
     
     var body: some View {
-        if #available(macOS 13.0, *) {
+        if #available(macOS 13.0, iOS 16.0, *) {
             content
                 .formStyle(.grouped)
         } else {

--- a/Shared/Views/Stock/StockInteraction/PurchaseProductView.swift
+++ b/Shared/Views/Stock/StockInteraction/PurchaseProductView.swift
@@ -266,6 +266,16 @@ struct PurchaseProductView: View {
                 MyToggle(isOn: $productDoesntSpoil, description: "str.stock.buy.product.doesntSpoil", descriptionInfo: nil, icon: MySymbols.doesntSpoil)
             }
             
+            if quickScan {
+                // This is a workaround for a bug which shows the toolbar multiple times
+                Text("")
+                    .toolbar(content: {
+                        ToolbarItem(placement: .confirmationAction, content: {
+                            toolbarContent
+                        })
+                    })
+            }
+            
             if !selfProduction {
                 Section(header: Text(LocalizedStringKey("str.stock.buy.product.price")).font(.headline)) {
                     VStack(alignment: .leading) {
@@ -310,16 +320,6 @@ struct PurchaseProductView: View {
                 })
             }
             MyTextField(textToEdit: $note, description: "str.stock.buy.product.note", isCorrect: Binding.constant(true), leadingIcon: MySymbols.description)
-            
-            if quickScan {
-                // This is a workaround for a bug which shows the toolbar multiple times
-                Text("")
-                    .toolbar(content: {
-                        ToolbarItem(placement: .confirmationAction, content: {
-                            toolbarContent
-                        })
-                    })
-            }
             
             MyToggle(isOn: $selfProduction, description: "str.stock.buy.product.selfProduction", icon: MySymbols.selfProduction)
             


### PR DESCRIPTION
I fixed a bug which is bad for the user experience.

Before you had to scroll down before you can see the confirm button for your purchase:
https://user-images.githubusercontent.com/6303931/235716724-142398ea-a47d-47e2-8ab0-7739133cf7bc.mp4

After I move up the relevant code the button instantly appears:
https://user-images.githubusercontent.com/6303931/235716968-1db84662-9de3-43e3-8a17-656a363414ef.mp4

The first commit was required to get a successful build in XCode

