### PR TITLE
Fix bug where HTTP requests were incorrectly cancelled

### DIFF
--- a/Shared/Model/GrocyAPI.swift
+++ b/Shared/Model/GrocyAPI.swift
@@ -262,19 +262,22 @@ public class GrocyApi: GrocyAPI {
         completion: @escaping (T?, Error?) -> Void
     ) throws {
         let dataTask = URLSession.shared.dataTask(with: urlRequest) { data, response, error in
+            guard let safeData = data else {
+                completion(nil, APIError.invalidResponse)
+                return
+            }
+            
             if let httpResponse = response as? HTTPURLResponse {
                 if (200...299).contains(httpResponse.statusCode) {
                     do {
-                        // TODO: remove force cast
-                        let responseDataDecoded = try JSONDecoder().decode(T.self, from: data!)
+                        let responseDataDecoded = try JSONDecoder().decode(T.self, from: safeData)
                         completion(responseDataDecoded, nil)
                     } catch {
                          completion(nil, APIError.decodingError(error: error))
                     }
                 } else {
                     do {
-                        // TODO: remove force cast
-                        let responseErrorDecoded = try JSONDecoder().decode(ErrorMessage.self, from: data!)
+                        let responseErrorDecoded = try JSONDecoder().decode(ErrorMessage.self, from: safeData)
                         completion(nil, APIError.errorString(description: responseErrorDecoded.errorMessage))
                     } catch {
                         completion(nil, APIError.decodingError(error: error))

--- a/Shared/Model/OpenFoodFacts/OpenFoodFactsViewModel.swift
+++ b/Shared/Model/OpenFoodFacts/OpenFoodFactsViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import Combine
 
 class OpenFoodFactsViewModel: ObservableObject {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     @Published var offData: OpenFoodFactsResult?
     @Published var errorMessage: String? = nil
     

--- a/Shared/Views/Additional/ServerProblemView.swift
+++ b/Shared/Views/Additional/ServerProblemView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ServerProblemView: View {
     var isCompact: Bool = false
     
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("devMode") private var devMode: Bool = false
     

--- a/Shared/Views/Admin/UserManagementView.swift
+++ b/Shared/Views/Admin/UserManagementView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct UserManagementView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var searchString: String = ""
     

--- a/Shared/Views/Admin/UserRowView.swift
+++ b/Shared/Views/Admin/UserRowView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct UserRowActionsView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var user: GrocyUser
     var isCurrentUser: Bool

--- a/Shared/Views/Components/AmountSelectionView.swift
+++ b/Shared/Views/Components/AmountSelectionView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct AmountSelectionView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Binding var productID: Int?
     @Binding var amount: Double

--- a/Shared/Views/Components/MyDoubleStepper.swift
+++ b/Shared/Views/Components/MyDoubleStepper.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MyDoubleStepper: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     @Binding var amount: Double
     
     var description: String
@@ -90,7 +90,7 @@ struct MyDoubleStepper: View {
 
 
 struct MyDoubleStepperOptional: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     @Binding var amount: Double?
     
     var description: String

--- a/Shared/Views/Components/ProductField.swift
+++ b/Shared/Views/Components/ProductField.swift
@@ -48,7 +48,7 @@ struct ProductField: View {
 #endif
     
     
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Binding var productID: Int?
     var description: String

--- a/Shared/Views/Components/ServerSettingsItems.swift
+++ b/Shared/Views/Components/ServerSettingsItems.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ServerSettingsToggle: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var isOn: Bool = false
     
@@ -60,7 +60,7 @@ struct ServerSettingsToggle: View {
 }
 
 struct ServerSettingsIntStepper: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var value: Int = 0
     
@@ -108,7 +108,7 @@ struct ServerSettingsIntStepper: View {
 }
 
 struct ServerSettingsDoubleStepper: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var value: Double = 0
     
@@ -156,7 +156,7 @@ struct ServerSettingsDoubleStepper: View {
 }
 
 struct ServerSettingsObjectPicker: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var objectID: Int? = nil
     

--- a/Shared/Views/MasterData/MDBarcodesView.swift
+++ b/Shared/Views/MasterData/MDBarcodesView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDBarcodeRowView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var barcode: MDProductBarcode
     
@@ -36,7 +36,7 @@ struct MDBarcodeRowView: View {
 }
 
 struct MDBarcodesView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var productID: Int
     
@@ -230,7 +230,7 @@ struct MDBarcodesView: View {
 }
 
 struct MDBarcodesView_Previews: PreviewProvider {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     static var previews: some View {
         NavigationView{
             MDBarcodesView(productID: 27, toastType: Binding.constant(nil))

--- a/Shared/Views/MasterData/MDBatteriesView.swift
+++ b/Shared/Views/MasterData/MDBatteriesView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDBatteriesView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var body: some View {
         VStack{

--- a/Shared/Views/MasterData/MDForms/MDBarcodeFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDBarcodeFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDBarcodeFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDForms/MDLocationFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDLocationFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDLocationFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDForms/MDProductFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDProductFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDProductFormOFFView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     @StateObject var offVM: OpenFoodFactsViewModel
     
     @Binding var name: String
@@ -96,7 +96,7 @@ struct MDProductFormOFFView: View {
 }
 
 struct MDProductFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDForms/MDProductGroupFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDProductGroupFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDProductGroupFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDForms/MDProductPictureFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDProductPictureFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDProductPictureFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var product: MDProduct?
     

--- a/Shared/Views/MasterData/MDForms/MDQuantityUnitConversionFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDQuantityUnitConversionFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDQuantityUnitConversionFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDForms/MDQuantityUnitFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDQuantityUnitFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDQuantityUnitFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDForms/MDShoppingLocationFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDShoppingLocationFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDStoreFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDForms/MDTaskCategoryFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDTaskCategoryFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDTaskCategoryFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDForms/MDUserEntityFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDUserEntityFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDUserEntityFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDForms/MDUserFieldFormView.swift
+++ b/Shared/Views/MasterData/MDForms/MDUserFieldFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDUserFieldFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDLocationsView.swift
+++ b/Shared/Views/MasterData/MDLocationsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDLocationRowView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var location: MDLocation
     
@@ -32,7 +32,7 @@ struct MDLocationRowView: View {
 }
 
 struct MDLocationsView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var searchString: String = ""
     

--- a/Shared/Views/MasterData/MDProductGroupsView.swift
+++ b/Shared/Views/MasterData/MDProductGroupsView.swift
@@ -24,7 +24,7 @@ struct MDProductGroupRowView: View {
 }
 
 struct MDProductGroupsView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDProductsView.swift
+++ b/Shared/Views/MasterData/MDProductsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MDProductRowView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var product: MDProduct
     
@@ -67,7 +67,7 @@ struct MDProductRowView: View {
 }
 
 struct MDProductsView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var searchString: String = ""
     

--- a/Shared/Views/MasterData/MDQuantityUnitsView.swift
+++ b/Shared/Views/MasterData/MDQuantityUnitsView.swift
@@ -28,7 +28,7 @@ struct MDQuantityUnitRowView: View {
 }
 
 struct MDQuantityUnitsView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDShoppingLocationsView.swift
+++ b/Shared/Views/MasterData/MDShoppingLocationsView.swift
@@ -24,7 +24,7 @@ struct MDStoreRowView: View {
 }
 
 struct MDStoresView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var searchString: String = ""
     

--- a/Shared/Views/MasterData/MDTaskCategoriesView.swift
+++ b/Shared/Views/MasterData/MDTaskCategoriesView.swift
@@ -24,7 +24,7 @@ struct MDTaskCategoryRowView: View {
 }
 
 struct MDTaskCategoriesView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDUserEntitiesView.swift
+++ b/Shared/Views/MasterData/MDUserEntitiesView.swift
@@ -21,7 +21,7 @@ struct MDUserEntityRowView: View {
 }
 
 struct MDUserEntitiesView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/MasterData/MDUserFieldsView.swift
+++ b/Shared/Views/MasterData/MDUserFieldsView.swift
@@ -25,7 +25,7 @@ struct MDUserFieldRowView: View {
 }
 
 struct MDUserFieldsView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/Navigation/AppSidebarNavigation.swift
+++ b/Shared/Views/Navigation/AppSidebarNavigation.swift
@@ -45,7 +45,7 @@ extension AppSidebarNavigation {
 }
 
 struct AppSidebarNavigation: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var firstAppear: Bool = true
     

--- a/Shared/Views/Onboarding/LoginView.swift
+++ b/Shared/Views/Onboarding/LoginView.swift
@@ -306,7 +306,7 @@ struct LoginStatusView: View {
     @State var loginState: LoginState
     var animation: Namespace.ID
     
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("demoServerURL") var demoServerURL: String = GrocyAPP.DemoServers.noLanguage.rawValue
     @AppStorage("grocyServerURL") var grocyServerURL: String = ""

--- a/Shared/Views/OpenFoodFacts/OpenFoodFactsFillProductView.swift
+++ b/Shared/Views/OpenFoodFacts/OpenFoodFactsFillProductView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct OpenFoodFactsFillProductView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     @ObservedObject var offVM: OpenFoodFactsViewModel = OpenFoodFactsViewModel()
     
     @Environment(\.dismiss) var dismiss

--- a/Shared/Views/OpenFoodFacts/OpenFoodFactsScannerView.swift
+++ b/Shared/Views/OpenFoodFacts/OpenFoodFactsScannerView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct OpenFoodFactsScannerView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var scanBarcode: String = ""
     @State private var isShowingResult: Bool = false

--- a/Shared/Views/Recipes/RecipeRowView.swift
+++ b/Shared/Views/Recipes/RecipeRowView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RecipeRowView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var recipe: Recipe
     

--- a/Shared/Views/Recipes/RecipesView.swift
+++ b/Shared/Views/Recipes/RecipesView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 
 struct RecipesView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
 #if os(iOS)
     private var idiom : UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }

--- a/Shared/Views/Settings/GrocyUserInfoView.swift
+++ b/Shared/Views/Settings/GrocyUserInfoView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct GrocyUserInfoView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var userPictureURL: URL? = nil
     

--- a/Shared/Views/Settings/LogView.swift
+++ b/Shared/Views/Settings/LogView.swift
@@ -10,7 +10,7 @@ import UniformTypeIdentifiers
 import OSLog
 
 struct LogView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("localizationKey") var localizationKey: String = "en"
     

--- a/Shared/Views/Settings/SettingsAppView.swift
+++ b/Shared/Views/Settings/SettingsAppView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SettingsAppView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("devMode") private var devMode: Bool = false
     

--- a/Shared/Views/Settings/SettingsShoppingListView.swift
+++ b/Shared/Views/Settings/SettingsShoppingListView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SettingsShoppingListView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("devMode") private var devMode: Bool = false
     @AppStorage("syncShoppingListToReminders") private var syncShoppingListToReminders: Bool = false

--- a/Shared/Views/Settings/SettingsStockView.swift
+++ b/Shared/Views/Settings/SettingsStockView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SettingsStockView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var useQuickConsume: Bool = false
     

--- a/Shared/Views/Settings/SettingsView.swift
+++ b/Shared/Views/Settings/SettingsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/ShoppingList/ShoppingListEntriesView.swift
+++ b/Shared/Views/ShoppingList/ShoppingListEntriesView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ShoppingListRowView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.colorScheme) var colorScheme
     
@@ -59,7 +59,7 @@ struct ShoppingListRowView: View {
 }
 
 struct ShoppingListEntriesView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.colorScheme) var colorScheme
     

--- a/Shared/Views/ShoppingList/ShoppingListEntryFormView.swift
+++ b/Shared/Views/ShoppingList/ShoppingListEntryFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ShoppingListEntryFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/ShoppingList/ShoppingListFormView.swift
+++ b/Shared/Views/ShoppingList/ShoppingListFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ShoppingListFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/ShoppingList/ShoppingListRowActionsView.swift
+++ b/Shared/Views/ShoppingList/ShoppingListRowActionsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ShoppingListRowActionsView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var shoppingListItem: ShoppingListItem
     

--- a/Shared/Views/ShoppingList/ShoppingListView.swift
+++ b/Shared/Views/ShoppingList/ShoppingListView.swift
@@ -13,7 +13,7 @@ struct ShoppingListItemWrapped {
 }
 
 struct ShoppingListView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var selectedShoppingListID: Int = 1
     

--- a/Shared/Views/Stock/StockEntriesView.swift
+++ b/Shared/Views/Stock/StockEntriesView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StockEntryRowView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("localizationKey") var localizationKey: String = "en"
     @Environment(\.colorScheme) var colorScheme
@@ -170,7 +170,7 @@ struct StockEntryRowView: View {
 }
 
 struct StockEntriesView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var stockElement: StockElement
     

--- a/Shared/Views/Stock/StockEntryFormView.swift
+++ b/Shared/Views/Stock/StockEntryFormView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StockEntryFormView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     @AppStorage("localizationKey") var localizationKey: String = "en"

--- a/Shared/Views/Stock/StockFilterActionsView.swift
+++ b/Shared/Views/Stock/StockFilterActionsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 private struct StockFilterItemView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     @Environment(\.colorScheme) var colorScheme
     var num: Int?
     @Binding var filteredStatus: ProductStatus

--- a/Shared/Views/Stock/StockFilterBarView.swift
+++ b/Shared/Views/Stock/StockFilterBarView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StockFilterBar: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Binding var searchString: String
     @Binding var filteredLocation: Int?

--- a/Shared/Views/Stock/StockInteraction/ConsumeProductView.swift
+++ b/Shared/Views/Stock/StockInteraction/ConsumeProductView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ConsumeProductView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/Stock/StockInteraction/InventoryProductView.swift
+++ b/Shared/Views/Stock/StockInteraction/InventoryProductView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct InventoryProductView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/Stock/StockInteraction/PurchaseProductView.swift
+++ b/Shared/Views/Stock/StockInteraction/PurchaseProductView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct PurchaseProductView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     @AppStorage("localizationKey") var localizationKey: String = "en"

--- a/Shared/Views/Stock/StockInteraction/TransferProductView.swift
+++ b/Shared/Views/Stock/StockInteraction/TransferProductView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TransferProductView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("localizationKey") var localizationKey: String = "en"
     

--- a/Shared/Views/Stock/StockJournalView.swift
+++ b/Shared/Views/Stock/StockJournalView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StockJournalFilterBar: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Binding var searchString: String
     @Binding var filteredProductID: Int?
@@ -185,7 +185,7 @@ struct StockJournalFilterBar: View {
 }
 
 struct StockJournalRowView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("localizationKey") var localizationKey: String = "en"
     
@@ -253,7 +253,7 @@ struct StockJournalRowView: View {
 }
 
 struct StockJournalView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/Stock/StockProductInfoView.swift
+++ b/Shared/Views/Stock/StockProductInfoView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StockProductInfoView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.dismiss) var dismiss
     

--- a/Shared/Views/Stock/StockTableMenuEntriesView.swift
+++ b/Shared/Views/Stock/StockTableMenuEntriesView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StockTableMenuEntriesView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var stockElement: StockElement
     @Binding var selectedStockElement: StockElement?

--- a/Shared/Views/Stock/StockTableRow.swift
+++ b/Shared/Views/Stock/StockTableRow.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StockTableRow: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("localizationKey") var localizationKey: String = "en"
     

--- a/Shared/Views/Stock/StockTableRowActionsView.swift
+++ b/Shared/Views/Stock/StockTableRowActionsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StockTableRowActionsView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     var stockElement: StockElement
     

--- a/Shared/Views/Stock/StockView.swift
+++ b/Shared/Views/Stock/StockView.swift
@@ -30,7 +30,7 @@ enum StockInteractionPopover: Identifiable {
 #endif
 
 struct StockView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State private var firstAppear: Bool = true
     

--- a/iOS/ActivitiesView.swift
+++ b/iOS/ActivitiesView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ActivitiesView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @State var toastType: ToastType?
     @State var infoString: String?

--- a/iOS/QuickScan/QuickScanModeInputView.swift
+++ b/iOS/QuickScan/QuickScanModeInputView.swift
@@ -12,7 +12,7 @@ enum ConsumeAmountMode {
 }
 
 struct QuickScanModeInputView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("localizationKey") var localizationKey: String = "en"
     

--- a/iOS/QuickScan/QuickScanModeSelectProductView.swift
+++ b/iOS/QuickScan/QuickScanModeSelectProductView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct QuickScanModeSelectProductView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("devMode") private var devMode: Bool = false
     @AppStorage("quickScanActionAfterAdd") private var quickScanActionAfterAdd: Bool = false

--- a/iOS/QuickScan/QuickScanModeView.swift
+++ b/iOS/QuickScan/QuickScanModeView.swift
@@ -31,7 +31,7 @@ enum QSActiveSheet: Identifiable {
 }
 
 struct QuickScanModeView: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @AppStorage("devMode") private var devMode: Bool = false
     @AppStorage("quickScanActionAfterAdd") private var quickScanActionAfterAdd: Bool = false

--- a/macOS/StockTable.swift
+++ b/macOS/StockTable.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StockTable: View {
-    @StateObject var grocyVM: GrocyViewModel = .shared
+    @ObservedObject var grocyVM: GrocyViewModel = .shared
     
     @Environment(\.colorScheme) var colorScheme
     


### PR DESCRIPTION
hopefully fixes #167 

---

First, I changed the HTTP call from `.data()` to `.dataTask()` with a completion handler. I did this, because I couldn't find out, which exact line was throwing the exception, when the request was cancelled.
Because I didn't want to change the rest of the class, I wrapped this new call inside `withCheckedThrowingContinuation()` to turn this into an async call.
This didn't fix the issue completely, because there was a new warning in the log:

> SWIFT TASK CONTINUATION MISUSE [...] leaked its continuation!

This error told me, what happened to the running tasks when navigating quickly: Something is wrong with the memory management of this class.
So I switched the property `grocyVM` in the views from `@SteteObject` to `@ObservedObject`, which is recommended for properties that are not created inside the view, but injected instead: https://www.avanderlee.com/swiftui/stateobject-observedobject-differences/#should-i-use-stateobject-for-all-views-using-the-same-instance