### PR TITLE
UserManagementView: Determine current user via /api/user

### DIFF
--- a/Grocy Mobile/Views/Admin/UserManagementView.swift
+++ b/Grocy Mobile/Views/Admin/UserManagementView.swift
@@ -12,7 +12,6 @@ struct UserManagementView: View {
     @Environment(GrocyViewModel.self) private var grocyVM
 
     @Query var users: GrocyUsers
-    @Query var systemConfigList: [SystemConfig]
 
     @State private var searchString: String = ""
 
@@ -20,7 +19,7 @@ struct UserManagementView: View {
 
     @State private var showAddUser: Bool = false
 
-    private let additionalDataToUpdate: [AdditionalEntities] = [.users, .system_config]
+    private let additionalDataToUpdate: [AdditionalEntities] = [.users, .current_user]
 
     private func updateData() async {
         await grocyVM.requestData(additionalObjects: additionalDataToUpdate)
@@ -117,7 +116,7 @@ struct UserManagementView: View {
                 Text("No users found").padding()
             }
             ForEach(filteredUsers, id: \.id) { user in
-                UserRowView(user: user, isCurrentUser: (systemConfigList.first?.userUsername == user.username))
+                UserRowView(user: user, isCurrentUser: (grocyVM.currentUser?.id == user.id))
             }
         }
         .navigationTitle("User management")


### PR DESCRIPTION
`isCurrentUser` in `UserManagementView` was derived from `USER_USERNAME` in `/api/system/config`. Grocy 4.7.0 removed that key (grocy commit `b6c07a51`), and making `userUsername` optional in dc3bd72 fixed the decoding error but left the value permanently `nil` against 4.7.0+ servers.

`isCurrentUser` is therefore always `false`, which disables the guard in `UserRowActionsView`:

```swift
.disabled(isCurrentUser)
```

The delete button is live on your own account, and grocy's `UsersApiController::DeleteUser` has no server-side self-deletion check.

This uses `grocyVM.currentUser`, populated from `/api/user`, and compares by `id` — the same approach `TasksView` and `ChoresView` already use. `/api/user` is present in both 4.6.0 and current grocy, so behaviour is unchanged on older servers. `.system_config` is no longer requested by this view, and the now-unused `systemConfigList` query is removed.

Built for iOS (Xcode 26.6, iOS 26.5 simulator SDK): `BUILD SUCCEEDED`. Not verified at runtime.